### PR TITLE
Update gender_inference_model_1.py

### DIFF
--- a/booknlp/english/gender_inference_model_1.py
+++ b/booknlp/english/gender_inference_model_1.py
@@ -163,7 +163,7 @@ class GenderEM:
 
 	def read_hyperparams(self, filename):
 		self.hyperparameters={}
-		with open(filename) as file:
+		with open(filename, encoding='UTF8') as file:
 			header=file.readline().rstrip()
 			gender_mapping={}
 			for idx, val in enumerate(header.split("\t")[2:]):


### PR DESCRIPTION
Complete error:
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1749: character maps to <undefined>

Fix:
Adding encoding='utf8' ensures Python decodes the file's bytes correctly using UTF-8, avoiding errors from mismatched default encodings.
